### PR TITLE
fix: adjust max width calculation for artwork title layout so

### DIFF
--- a/liturgical_calendar/image_generation/layout_engine.py
+++ b/liturgical_calendar/image_generation/layout_engine.py
@@ -184,7 +184,7 @@ class LayoutEngine:
     ) -> Dict[str, Any]:
         """Return layout info for the artwork title, including wrapped lines and positions."""
         font = fonts["serif_96"]
-        max_width = width - 2 * padding
+        max_width = width - 4 * padding
 
         # Wrap text
         def wrap_text(text, font, max_width):


### PR DESCRIPTION
Doubles the left and right padding around the title so ensure it doesn’t get cut off by the frame.

fixes #17